### PR TITLE
Add missing expect clause

### DIFF
--- a/guides/micronaut-rest-assured/groovy/src/test/groovy/example/micronaut/HelloControllerSpec.groovy
+++ b/guides/micronaut-rest-assured/groovy/src/test/groovy/example/micronaut/HelloControllerSpec.groovy
@@ -14,6 +14,7 @@ class HelloControllerSpec extends Specification {
     RequestSpecification spec // <2>
 
     void "test hello endpoint"() {
+        expect:
         spec    // <3>
             .when()
                 .get('/hello')


### PR DESCRIPTION
When running test without `expect:` clause no tests were found by runner.